### PR TITLE
Remove kotlin-reflect so that this library can be used in Android applications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ repositories {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
-    compile "org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}"
 
     testCompile 'org.assertj:assertj-core:3.8.0'
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.0.0-RC2'


### PR DESCRIPTION
In Android applications, you usually want to avoid `kotlin-reflect` as it is a pretty bulky dependency.

Since `resultkt` doesn’t need the Kotlin reflection (all tests pass if you remove it), it can be safely removed.